### PR TITLE
include search results within the visible plugin

### DIFF
--- a/client/search.coffee
+++ b/client/search.coffee
@@ -27,11 +27,11 @@ emit = ($item, item) ->
     "<div class=report>#{report item.result}</div>"
   else
     """
-      <div style="width:93%; background:#eee; padding:.8em; margin-bottom:5px; text-align: center;">
+      <div style="width:93%; background:#eee; padding:16px; margin-bottom:5px; text-align: center;">
         <span>#{expand item.text}<br></span>
         <p class="caption">ready</p>
+        <div class=report style="text-align:left;"></div>
       </div>
-      <div class=report></div>
     """
 
   status = (text) ->


### PR DESCRIPTION
This small adjustment makes it clear where the search results came from. This became especially clear to me when I lined it up with other plugins that embeds results. Here is the new look.

![image](https://user-images.githubusercontent.com/12127/35208327-a9d38702-fefc-11e7-9f2d-4c7efa291548.png)
