### PR TITLE
Prevent left/right keypress from bubbling

### DIFF
--- a/client/search.coffee
+++ b/client/search.coffee
@@ -64,12 +64,17 @@ emit = ($item, item) ->
         request.query += " #{input}"
         search request
 
+  stopBubble = (e) ->
+    if e.keyCode is 37 or e.keyCode is 39
+      e.stopPropagation()
+
   handle = (request) ->
     if request.input
       $item.request = request
       $item
         .find('span')
         .append '<input type=text style="width: 95%;"></input>'
+        .keydown(stopBubble)
         .keyup(keystroke)
     else if request.search
       $item.request = request
@@ -111,4 +116,3 @@ bind = ($item, item) ->
 
 window.plugins.search = {emit, bind} if window?
 module.exports = {expand} if module?
-


### PR DESCRIPTION
Prevent left/right key press from bubbling up to the wiki page and causing navigation within the lineup and the input field loosing focus.

See also https://github.com/fedwiki/wiki-client/issues/233, and https://github.com/fedwiki/wiki-client/pull/234