### PR TITLE
only parse and handle text field if it exists, and is not just spaces

### DIFF
--- a/client/search.coffee
+++ b/client/search.coffee
@@ -103,7 +103,8 @@ emit = ($item, item) ->
     request.query = text
     request
 
-  handle parse item.text if item.text?
+  # only if item.text is present, and not all spaces
+  handle parse item.text if item.text? and item.text.trim().length > 0
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item


### PR DESCRIPTION
Adding just a text field with space is not enough, as this will cause parsing of the text.

So, only parse if the text is not just spaces.