### PR TITLE
Makes input boxes of search plugin work better on mobile

### DIFF
--- a/client/search.js
+++ b/client/search.js
@@ -78,7 +78,7 @@ const emit = ($item, item) => {
   const handle = request => {
     if (request.input) {
       $item.request = request
-      $item.find('span').append('<input type=text style="width: 95%;"></input>').on('keyup', keystroke)
+      $item.find('span').append('<input type=search style="width: 95%;"></input>').on('keyup', keystroke)
     } else if (request.search) {
       $item.request = request
       $item


### PR DESCRIPTION
This change makes the input boxes of the search plugin work better on mobile. Changing the input type to "search" makes it so that the virtual keyboard that pops up on mobile devices has a search button where the enter key normally is, so that clicking it will execute the search. Currently, with the type set to "text", the enter button on mobile keyboards is changed into a tab button, because the browser sees, the input box for the search in the wiki footer, and thinks the user might want to tab over there instead of executing the search. (i.e. I can't execute the search at all on my mobile phone.)